### PR TITLE
Bump php version requirement in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,7 +41,7 @@ You can read more about this command in `here <https://getcomposer.org/doc/03-cl
 
 Troubleshooting
 ----------------
-Searcher has just one requirement (PHP language version >=5.4), but it has several development requirements,
+Searcher has just one requirement (PHP language version >=7.0), but it has several development requirements,
 which can require some PHP extensions, like ``ext-mongo``. If you do not have this extension installed on your system,
 but you still want to test this library without installing it you can use flag ``--ignore-platform-reqs`` to tell composer
 that it should not check for PHP extensions on your system. Whole installation command in this case will look like this:


### PR DESCRIPTION
Per the **Latest version is supporting only PHP 7** in the [introduction](https://github.com/krzysztof-gzocha/searcher/blob/master/docs/introduction.rst#what).

I'm _assuming_ this should be updated, since the install would be sad on php < 7.0?